### PR TITLE
fix the problem of exporting incorrect fields(1 to 1 relation) into c…

### DIFF
--- a/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
+++ b/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
@@ -687,6 +687,11 @@ class Table extends BaseTable
             if ($this->isLocalForeignKeyIgnored($local)) {
                 continue;
             }
+            
+            if(!$local->isManyToOne()) {
+                continue;
+            }
+
             $this->getDocument()->addLog(sprintf('  Writing N <=> 1 constructor "%s"', $local->getOwningTable()->getModelName()));
 
             $related = $local->getForeignM2MRelatedName();


### PR DESCRIPTION
關聯是一對一的時候, 產生出來的entity 的constructor會多一行錯誤的code
![1708495869307](https://github.com/hamichen/doctrine2-exporter/assets/160706943/bdb53b0a-287e-409b-892d-f46e22b5c19a)

doctrine2-exporter/lib/MwbExporter/Formatter/Doctrine2/Annotation/Model/Table.php
的writeRelationsConstructor 裡面排除掉一對一的關聯